### PR TITLE
题集API设计、部分接口实现及集成测试

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,5 @@ go.work
 
 .idea
 /go.work.sum
-/internal/user/internal/integration/logs/
+logs
 config/local.yaml
-
-/internal/baguwen/internal/integration/logs/

--- a/.script/integrate_test.sh
+++ b/.script/integrate_test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-docker compose -f .script/integration_test_compose.yml down
+docker compose -f .script/integration_test_compose.yml down -v
 docker compose -f .script/integration_test_compose.yml up -d
 go test  ./...  -tags=e2e
-docker compose -f .script/integration_test_compose.yml down
+docker compose -f .script/integration_test_compose.yml down -v

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ e2e_up:
 
 .PHONY: e2e_down
 e2e_down:
-	docker compose -f .script/integration_test_compose.yml down
+	docker compose -f .script/integration_test_compose.yml down -v
 
 .PHONY: mock
 

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,5 @@ e2e_down:
 	docker compose -f .script/integration_test_compose.yml down -v
 
 .PHONY: mock
-
 mock:
 	mockgen -destination=test/mocks/session.mock.go -package=mocks github.com/ecodeclub/ginx/session Session

--- a/internal/interactive/internal/web/handler.go
+++ b/internal/interactive/internal/web/handler.go
@@ -36,12 +36,12 @@ func (h *Handler) PrivateRoutes(server *gin.Engine) {
 }
 
 func (h *Handler) PublicRoutes(server *gin.Engine) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (h *Handler) Collect(ctx *ginx.Context, req CollectReq, sess session.Session) (ginx.Result, error) {
-	return ginx.Result{Msg: "OK"}, nil
+	return systemErrorResult, nil
 }
 
 func (h *Handler) GetCnt(ctx *ginx.Context, req GetCntReq, sess session.Session) (ginx.Result, error) {

--- a/internal/question/internal/domain/question_set.go
+++ b/internal/question/internal/domain/question_set.go
@@ -1,3 +1,17 @@
+// Copyright 2023 ecodeclub
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package domain
 
 import "time"

--- a/internal/question/internal/domain/question_set.go
+++ b/internal/question/internal/domain/question_set.go
@@ -1,0 +1,18 @@
+package domain
+
+import "time"
+
+// QuestionSet 题集实体
+type QuestionSet struct {
+	Id  int64
+	Uid int64
+	// 标题
+	Title string
+	// 描述
+	Description string
+
+	// 题集中引用的题目,
+	Questions []Question
+
+	Utime time.Time
+}

--- a/internal/question/internal/integration/startup/wire.go
+++ b/internal/question/internal/integration/startup/wire.go
@@ -27,3 +27,8 @@ func InitHandler() (*web.Handler, error) {
 	wire.Build(testioc.BaseSet, baguwen.InitHandler)
 	return new(web.Handler), nil
 }
+
+func InitQuestionSetHandler() (*web.QuestionSetHandler, error) {
+	wire.Build(testioc.BaseSet, baguwen.InitQuestionSetHandler)
+	return new(web.QuestionSetHandler), nil
+}

--- a/internal/question/internal/integration/startup/wire_gen.go
+++ b/internal/question/internal/integration/startup/wire_gen.go
@@ -23,3 +23,13 @@ func InitHandler() (*web.Handler, error) {
 	}
 	return handler, nil
 }
+
+func InitQuestionSetHandler() (*web.QuestionSetHandler, error) {
+	db := testioc.InitDB()
+	cache := testioc.InitCache()
+	questionSetHandler, err := baguwen.InitQuestionSetHandler(db, cache)
+	if err != nil {
+		return nil, err
+	}
+	return questionSetHandler, nil
+}

--- a/internal/question/internal/repository/dao/init.go
+++ b/internal/question/internal/repository/dao/init.go
@@ -22,5 +22,7 @@ func InitTables(db *egorm.Component) error {
 		&PublishQuestion{},
 		&AnswerElement{},
 		&PublishAnswerElement{},
+		&QuestionSet{},
+		&QuestionSetQuestion{},
 	)
 }

--- a/internal/question/internal/repository/dao/question_set.go
+++ b/internal/question/internal/repository/dao/question_set.go
@@ -1,0 +1,210 @@
+package dao
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/ecodeclub/ekit/slice"
+	"github.com/ego-component/egorm"
+	"github.com/go-sql-driver/mysql"
+	"github.com/gotomicro/ego/core/elog"
+	"gorm.io/gorm"
+)
+
+var (
+	ErrDuplicatedQuestionID = errors.New("问题ID重复")
+)
+
+type QuestionSetDAO interface {
+	Create(ctx context.Context, qs QuestionSet) (int64, error)
+	GetByID(ctx context.Context, id int64) (QuestionSet, error)
+	// List(ctx context.Context, offset int, limit int, uid int64) ([]Question, error)
+
+	GetQuestionsByID(ctx context.Context, id int64) ([]Question, error)
+	UpdateQuestionsByID(ctx context.Context, id int64, qs []Question) error
+	AddQuestionsByID(ctx context.Context, id int64, qs []Question) error
+	DeleteQuestionsByID(ctx context.Context, id int64, qs []Question) error
+
+	// Count(ctx context.Context, uid int64) (int64, error)
+	//
+	// Sync(ctx context.Context, que Question, eles []AnswerElement) (int64, error)
+	//
+	// // 线上库 API
+	// PubList(ctx context.Context, offset int, limit int) ([]PublishQuestion, error)
+	// PubCount(ctx context.Context) (int64, error)
+	// GetPubByID(ctx context.Context, qid int64) (PublishQuestion, []PublishAnswerElement, error)
+}
+
+type GORMQuestionSetDAO struct {
+	db *egorm.Component
+}
+
+func NewGORMQuestionSetDAO(db *egorm.Component) QuestionSetDAO {
+	return &GORMQuestionSetDAO{db: db}
+}
+
+func (g *GORMQuestionSetDAO) Create(ctx context.Context, qs QuestionSet) (int64, error) {
+	now := time.Now().UnixMilli()
+	qs.Ctime, qs.Utime = now, now
+	err := g.db.WithContext(ctx).Create(&qs).Error
+	return qs.Id, err
+}
+
+func (g *GORMQuestionSetDAO) GetByID(ctx context.Context, id int64) (QuestionSet, error) {
+	var qs QuestionSet
+	err := g.db.WithContext(ctx).First(&qs, "id = ?", id).Error
+	return qs, err
+}
+
+func (g *GORMQuestionSetDAO) GetQuestionsByID(ctx context.Context, id int64) ([]Question, error) {
+	var q []Question
+	err := g.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var qsq []QuestionSetQuestion
+		if err := tx.WithContext(ctx).Find(&qsq, "question_set_id = ?", id).Error; err != nil {
+			return err
+		}
+		questionIDs := make([]int64, len(qsq))
+		for i := range qsq {
+			questionIDs[i] = qsq[i].QuestionID
+		}
+		return tx.WithContext(ctx).Where("id IN ?", questionIDs).Order("id ASC").Find(&q).Error
+	})
+	return q, err
+}
+
+func (g *GORMQuestionSetDAO) UpdateQuestionsByID(ctx context.Context, id int64, questions []Question) error {
+	return g.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		log.Println("UpdateQuestionsByID Invoked!")
+		// 获取题集中的目标题目集合
+		targetQuestionIDs := make([]int64, len(questions))
+		for i := range questions {
+			targetQuestionIDs[i] = questions[i].Id
+		}
+
+		log.Printf("targetQuestionIDs = %#v\n", targetQuestionIDs)
+
+		// 检查目标问题ID是否合法
+		var count int64
+		if err := tx.WithContext(ctx).Model(&Question{}).Where("id IN ?", targetQuestionIDs).Count(&count).Error; err != nil {
+			return err
+		}
+		if int64(len(questions)) != count {
+			return fmt.Errorf("问题ID非法")
+		}
+
+		log.Println("UpdateQuestionsByID Invoked!3")
+
+		// 题集中现有的问题ID集合
+		var currentQuestions []QuestionSetQuestion
+		if err := tx.WithContext(ctx).Find(&currentQuestions, "question_set_id = ?", id).Error; err != nil {
+			log.Println("err >>>>>", err)
+			return err
+		}
+		currentQuestionIDs := make([]int64, len(currentQuestions))
+		for i := range currentQuestions {
+			currentQuestionIDs[i] = currentQuestions[i].QuestionID
+		}
+
+		log.Printf("currentQuestionIDs = %#v\n", currentQuestionIDs)
+
+		log.Println("UpdateQuestionsByID Invoked!4")
+
+		// 在当前问题集合中但不在目标问题集合中 —— 删除问题
+		needDelete := slice.DiffSet(currentQuestionIDs, targetQuestionIDs)
+		if len(needDelete) > 0 {
+			err := tx.WithContext(ctx).Where("question_set_id = ? AND question_id IN ?", id, needDelete).Delete(&QuestionSetQuestion{}).Error
+			if err != nil {
+				return err
+			}
+		}
+
+		log.Printf("needDelete = %#v\n", needDelete)
+
+		// 在目标问题集合中但不在当前问题集合中 —— 新增问题
+		needCreate := slice.DiffSet(targetQuestionIDs, currentQuestionIDs)
+		if len(needCreate) > 0 {
+			now := time.Now().UnixMilli()
+			var newQuestions []QuestionSetQuestion
+			for i := range needCreate {
+				newQuestions = append(newQuestions, QuestionSetQuestion{
+					QuestionSetID: id,
+					QuestionID:    needCreate[i],
+					Ctime:         now,
+					Utime:         now,
+				})
+			}
+			if err := tx.WithContext(ctx).Create(&newQuestions).Error; err != nil {
+				return err
+			}
+		}
+		log.Printf("needCreate = %#v\n", needCreate)
+		log.Println("UpdateQuestionsByID Invoked!5")
+		return nil
+	})
+}
+
+func (g *GORMQuestionSetDAO) AddQuestionsByID(ctx context.Context, id int64, questions []Question) error {
+	return g.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+
+		questionIDs, err := g.getQuestionIDs(ctx, tx, questions)
+		if err != nil {
+			return err
+		}
+
+		now := time.Now().UnixMilli()
+		newQuestions := make([]QuestionSetQuestion, 0, len(questionIDs))
+		for i := range questionIDs {
+			newQuestions = append(newQuestions, QuestionSetQuestion{
+				QuestionSetID: id,
+				QuestionID:    questionIDs[i],
+				Ctime:         now,
+				Utime:         now,
+			})
+		}
+		err = tx.WithContext(ctx).Create(&newQuestions).Error
+		if g.isMySQLUniqueIndexError(err) {
+			return fmt.Errorf("%w", ErrDuplicatedQuestionID)
+		}
+		return err
+	})
+}
+
+func (g *GORMQuestionSetDAO) isMySQLUniqueIndexError(err error) bool {
+	me := new(mysql.MySQLError)
+	if ok := errors.As(err, &me); ok {
+		elog.Error("mysql", elog.FieldValue(fmt.Sprintf("%#v", err)))
+		const uniqueIndexErrNo uint16 = 1062
+		return me.Number == uniqueIndexErrNo
+	}
+	return false
+}
+
+func (g *GORMQuestionSetDAO) getQuestionIDs(ctx context.Context, tx *gorm.DB, questions []Question) ([]int64, error) {
+	questionIDs := make([]int64, len(questions))
+	for i := range questions {
+		questionIDs[i] = questions[i].Id
+	}
+
+	// 检查目标问题ID是否合法
+	var count int64
+	if err := tx.WithContext(ctx).Model(&Question{}).Where("id IN ?", questionIDs).Count(&count).Error; err != nil {
+		return nil, err
+	}
+	if int64(len(questions)) != count {
+		return nil, fmt.Errorf("问题ID非法")
+	}
+	return questionIDs, nil
+}
+
+func (g *GORMQuestionSetDAO) DeleteQuestionsByID(ctx context.Context, id int64, questions []Question) error {
+	return g.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		questionIDs, err := g.getQuestionIDs(ctx, tx, questions)
+		if err != nil {
+			return err
+		}
+		return tx.WithContext(ctx).Where("question_set_id = ? AND question_id IN ?", id, questionIDs).Delete(&QuestionSetQuestion{}).Error
+	})
+}

--- a/internal/question/internal/repository/dao/question_set.go
+++ b/internal/question/internal/repository/dao/question_set.go
@@ -2,20 +2,11 @@ package dao
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"log"
 	"time"
 
-	"github.com/ecodeclub/ekit/slice"
 	"github.com/ego-component/egorm"
-	"github.com/go-sql-driver/mysql"
-	"github.com/gotomicro/ego/core/elog"
 	"gorm.io/gorm"
-)
-
-var (
-	ErrDuplicatedQuestionID = errors.New("问题ID重复")
 )
 
 type QuestionSetDAO interface {
@@ -24,9 +15,7 @@ type QuestionSetDAO interface {
 	// List(ctx context.Context, offset int, limit int, uid int64) ([]Question, error)
 
 	GetQuestionsByID(ctx context.Context, id int64) ([]Question, error)
-	UpdateQuestionsByID(ctx context.Context, id int64, qs []Question) error
-	AddQuestionsByID(ctx context.Context, id int64, qs []Question) error
-	DeleteQuestionsByID(ctx context.Context, id int64, qs []Question) error
+	UpdateQuestionsByID(ctx context.Context, id int64, qids []int64) error
 
 	// Count(ctx context.Context, uid int64) (int64, error)
 	//
@@ -63,148 +52,53 @@ func (g *GORMQuestionSetDAO) GetQuestionsByID(ctx context.Context, id int64) ([]
 	var q []Question
 	err := g.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var qsq []QuestionSetQuestion
-		if err := tx.WithContext(ctx).Find(&qsq, "question_set_id = ?", id).Error; err != nil {
+		if err := tx.WithContext(ctx).Find(&qsq, "qs_id = ?", id).Error; err != nil {
 			return err
 		}
 		questionIDs := make([]int64, len(qsq))
 		for i := range qsq {
-			questionIDs[i] = qsq[i].QuestionID
+			questionIDs[i] = qsq[i].QID
 		}
 		return tx.WithContext(ctx).Where("id IN ?", questionIDs).Order("id ASC").Find(&q).Error
 	})
 	return q, err
 }
 
-func (g *GORMQuestionSetDAO) UpdateQuestionsByID(ctx context.Context, id int64, questions []Question) error {
+func (g *GORMQuestionSetDAO) UpdateQuestionsByID(ctx context.Context, id int64, qids []int64) error {
 	return g.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		log.Println("UpdateQuestionsByID Invoked!")
-		// 获取题集中的目标题目集合
-		targetQuestionIDs := make([]int64, len(questions))
-		for i := range questions {
-			targetQuestionIDs[i] = questions[i].Id
-		}
 
-		log.Printf("targetQuestionIDs = %#v\n", targetQuestionIDs)
-
-		// 检查目标问题ID是否合法
-		var count int64
-		if err := tx.WithContext(ctx).Model(&Question{}).Where("id IN ?", targetQuestionIDs).Count(&count).Error; err != nil {
+		// 全部删除
+		if err := tx.WithContext(ctx).Where("qs_id = ?", id).Delete(&QuestionSetQuestion{}).Error; err != nil {
 			return err
 		}
-		if int64(len(questions)) != count {
+
+		if len(qids) == 0 {
+			return nil
+		}
+
+		// 检查问题ID合法性
+		var count int64
+		if err := tx.WithContext(ctx).Model(&Question{}).Where("id IN ?", qids).Count(&count).Error; err != nil {
+			return err
+		}
+		if int64(len(qids)) != count {
 			return fmt.Errorf("问题ID非法")
 		}
 
-		log.Println("UpdateQuestionsByID Invoked!3")
-
-		// 题集中现有的问题ID集合
-		var currentQuestions []QuestionSetQuestion
-		if err := tx.WithContext(ctx).Find(&currentQuestions, "question_set_id = ?", id).Error; err != nil {
-			log.Println("err >>>>>", err)
-			return err
-		}
-		currentQuestionIDs := make([]int64, len(currentQuestions))
-		for i := range currentQuestions {
-			currentQuestionIDs[i] = currentQuestions[i].QuestionID
-		}
-
-		log.Printf("currentQuestionIDs = %#v\n", currentQuestionIDs)
-
-		log.Println("UpdateQuestionsByID Invoked!4")
-
-		// 在当前问题集合中但不在目标问题集合中 —— 删除问题
-		needDelete := slice.DiffSet(currentQuestionIDs, targetQuestionIDs)
-		if len(needDelete) > 0 {
-			err := tx.WithContext(ctx).Where("question_set_id = ? AND question_id IN ?", id, needDelete).Delete(&QuestionSetQuestion{}).Error
-			if err != nil {
-				return err
-			}
-		}
-
-		log.Printf("needDelete = %#v\n", needDelete)
-
-		// 在目标问题集合中但不在当前问题集合中 —— 新增问题
-		needCreate := slice.DiffSet(targetQuestionIDs, currentQuestionIDs)
-		if len(needCreate) > 0 {
-			now := time.Now().UnixMilli()
-			var newQuestions []QuestionSetQuestion
-			for i := range needCreate {
-				newQuestions = append(newQuestions, QuestionSetQuestion{
-					QuestionSetID: id,
-					QuestionID:    needCreate[i],
-					Ctime:         now,
-					Utime:         now,
-				})
-			}
-			if err := tx.WithContext(ctx).Create(&newQuestions).Error; err != nil {
-				return err
-			}
-		}
-		log.Printf("needCreate = %#v\n", needCreate)
-		log.Println("UpdateQuestionsByID Invoked!5")
-		return nil
-	})
-}
-
-func (g *GORMQuestionSetDAO) AddQuestionsByID(ctx context.Context, id int64, questions []Question) error {
-	return g.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-
-		questionIDs, err := g.getQuestionIDs(ctx, tx, questions)
-		if err != nil {
-			return err
-		}
-
+		// 重新创建
 		now := time.Now().UnixMilli()
-		newQuestions := make([]QuestionSetQuestion, 0, len(questionIDs))
-		for i := range questionIDs {
+		var newQuestions []QuestionSetQuestion
+		for i := range qids {
 			newQuestions = append(newQuestions, QuestionSetQuestion{
-				QuestionSetID: id,
-				QuestionID:    questionIDs[i],
-				Ctime:         now,
-				Utime:         now,
+				QSID:  id,
+				QID:   qids[i],
+				Ctime: now,
+				Utime: now,
 			})
 		}
-		err = tx.WithContext(ctx).Create(&newQuestions).Error
-		if g.isMySQLUniqueIndexError(err) {
-			return fmt.Errorf("%w", ErrDuplicatedQuestionID)
-		}
-		return err
-	})
-}
-
-func (g *GORMQuestionSetDAO) isMySQLUniqueIndexError(err error) bool {
-	me := new(mysql.MySQLError)
-	if ok := errors.As(err, &me); ok {
-		elog.Error("mysql", elog.FieldValue(fmt.Sprintf("%#v", err)))
-		const uniqueIndexErrNo uint16 = 1062
-		return me.Number == uniqueIndexErrNo
-	}
-	return false
-}
-
-func (g *GORMQuestionSetDAO) getQuestionIDs(ctx context.Context, tx *gorm.DB, questions []Question) ([]int64, error) {
-	questionIDs := make([]int64, len(questions))
-	for i := range questions {
-		questionIDs[i] = questions[i].Id
-	}
-
-	// 检查目标问题ID是否合法
-	var count int64
-	if err := tx.WithContext(ctx).Model(&Question{}).Where("id IN ?", questionIDs).Count(&count).Error; err != nil {
-		return nil, err
-	}
-	if int64(len(questions)) != count {
-		return nil, fmt.Errorf("问题ID非法")
-	}
-	return questionIDs, nil
-}
-
-func (g *GORMQuestionSetDAO) DeleteQuestionsByID(ctx context.Context, id int64, questions []Question) error {
-	return g.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		questionIDs, err := g.getQuestionIDs(ctx, tx, questions)
-		if err != nil {
+		if err := tx.WithContext(ctx).Create(&newQuestions).Error; err != nil {
 			return err
 		}
-		return tx.WithContext(ctx).Where("question_set_id = ? AND question_id IN ?", id, questionIDs).Delete(&QuestionSetQuestion{}).Error
+		return nil
 	})
 }

--- a/internal/question/internal/repository/dao/types.go
+++ b/internal/question/internal/repository/dao/types.go
@@ -76,13 +76,9 @@ type QuestionSet struct {
 
 // QuestionSetQuestion 题集问题 —— 题集与题目的关联关系
 type QuestionSetQuestion struct {
-	Id            int64 `gorm:"primaryKey,autoIncrement"`
-	QuestionSetID int64 `gorm:"uniqueIndex:qsid_qid"`
-	QuestionID    int64 `gorm:"uniqueIndex:qsid_qid"`
-	// // 题目标题
-	// Title string
-	// // 题目内容
-	// Content string
+	Id    int64 `gorm:"primaryKey,autoIncrement"`
+	QSID  int64 `gorm:"uniqueIndex:qsid_qid"`
+	QID   int64 `gorm:"uniqueIndex:qsid_qid"`
 	Ctime int64
 	Utime int64 `gorm:"index"`
 }

--- a/internal/question/internal/repository/dao/types.go
+++ b/internal/question/internal/repository/dao/types.go
@@ -60,6 +60,33 @@ type AnswerElement struct {
 	Utime int64
 }
 
+// QuestionSet 题集 属于个人
+type QuestionSet struct {
+	Id int64 `gorm:"primaryKey,autoIncrement"`
+	// 所有者
+	Uid int64 `gorm:"index"`
+	// 题集标题
+	Title string
+	// 题集描述
+	Description string
+
+	Ctime int64
+	Utime int64 `gorm:"index"`
+}
+
+// QuestionSetQuestion 题集问题 —— 题集与题目的关联关系
+type QuestionSetQuestion struct {
+	Id            int64 `gorm:"primaryKey,autoIncrement"`
+	QuestionSetID int64 `gorm:"uniqueIndex:qsid_qid"`
+	QuestionID    int64 `gorm:"uniqueIndex:qsid_qid"`
+	// // 题目标题
+	// Title string
+	// // 题目内容
+	// Content string
+	Ctime int64
+	Utime int64 `gorm:"index"`
+}
+
 const (
 	AnswerElementTypeUnknown = iota
 	AnswerElementTypeAnalysis

--- a/internal/question/internal/repository/question_set.go
+++ b/internal/question/internal/repository/question_set.go
@@ -1,0 +1,91 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/ecodeclub/ekit/bean/copier"
+	"github.com/ecodeclub/ekit/bean/copier/converter"
+	"github.com/ecodeclub/webook/internal/question/internal/domain"
+	"github.com/ecodeclub/webook/internal/question/internal/repository/dao"
+	"github.com/gotomicro/ego/core/elog"
+)
+
+var (
+	ErrDuplicatedQuestionID = dao.ErrDuplicatedQuestionID
+)
+
+type QuestionSetRepository interface {
+	Create(ctx context.Context, set domain.QuestionSet) (int64, error)
+
+	UpdateQuestions(ctx context.Context, set domain.QuestionSet) error
+	AddQuestions(ctx context.Context, set domain.QuestionSet) error
+	DeleteQuestions(ctx context.Context, set domain.QuestionSet) error
+}
+
+type questionSetRepository struct {
+	dao            dao.QuestionSetDAO
+	questionSetD2E copier.Copier[domain.QuestionSet, dao.QuestionSet]
+	questionD2E    copier.Copier[domain.Question, dao.Question]
+	logger         *elog.Component
+}
+
+func NewQuestionSetRepository(d dao.QuestionSetDAO) QuestionSetRepository {
+	fieldConverter := converter.ConverterFunc[time.Time, int64](func(src time.Time) (int64, error) {
+		return src.UnixMilli(), nil
+	})
+	questionSetD2E, err := copier.NewReflectCopier[domain.QuestionSet, dao.QuestionSet](
+		copier.IgnoreFields("Questions"),
+		copier.ConvertField[time.Time, int64]("Utime", fieldConverter),
+	)
+	if err != nil {
+		panic(err)
+	}
+	questionD2E, err := copier.NewReflectCopier[domain.Question, dao.Question](
+		copier.ConvertField[time.Time, int64]("Utime", fieldConverter),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+	return &questionSetRepository{
+		dao:            d,
+		questionSetD2E: questionSetD2E,
+		questionD2E:    questionD2E,
+		logger:         elog.DefaultLogger}
+}
+
+func (q *questionSetRepository) Create(ctx context.Context, set domain.QuestionSet) (int64, error) {
+	d, err := q.questionSetD2E.Copy(&set)
+	if err != nil {
+		return 0, err
+	}
+	return q.dao.Create(ctx, *d)
+}
+
+func (q *questionSetRepository) UpdateQuestions(ctx context.Context, set domain.QuestionSet) error {
+	questions := make([]dao.Question, len(set.Questions))
+	for i := range set.Questions {
+		d, _ := q.questionD2E.Copy(&set.Questions[i])
+		questions[i] = *d
+	}
+	return q.dao.UpdateQuestionsByID(ctx, set.Id, questions)
+}
+
+func (q *questionSetRepository) AddQuestions(ctx context.Context, set domain.QuestionSet) error {
+	questions := make([]dao.Question, len(set.Questions))
+	for i := range set.Questions {
+		d, _ := q.questionD2E.Copy(&set.Questions[i])
+		questions[i] = *d
+	}
+	return q.dao.AddQuestionsByID(ctx, set.Id, questions)
+}
+
+func (q *questionSetRepository) DeleteQuestions(ctx context.Context, set domain.QuestionSet) error {
+	questions := make([]dao.Question, len(set.Questions))
+	for i := range set.Questions {
+		d, _ := q.questionD2E.Copy(&set.Questions[i])
+		questions[i] = *d
+	}
+	return q.dao.DeleteQuestionsByID(ctx, set.Id, questions)
+}

--- a/internal/question/internal/repository/question_set.go
+++ b/internal/question/internal/repository/question_set.go
@@ -82,7 +82,7 @@ func (q *questionSetRepository) GetByID(ctx context.Context, id int64) (domain.Q
 		Title:       set.Title,
 		Description: set.Description,
 		Questions:   questions,
-		Utime:       time.Unix(set.Utime, 0),
+		Utime:       time.Unix(0, set.Utime*int64(time.Millisecond)),
 	}, nil
 }
 

--- a/internal/question/internal/repository/question_set.go
+++ b/internal/question/internal/repository/question_set.go
@@ -11,16 +11,9 @@ import (
 	"github.com/gotomicro/ego/core/elog"
 )
 
-var (
-	ErrDuplicatedQuestionID = dao.ErrDuplicatedQuestionID
-)
-
 type QuestionSetRepository interface {
 	Create(ctx context.Context, set domain.QuestionSet) (int64, error)
-
 	UpdateQuestions(ctx context.Context, set domain.QuestionSet) error
-	AddQuestions(ctx context.Context, set domain.QuestionSet) error
-	DeleteQuestions(ctx context.Context, set domain.QuestionSet) error
 }
 
 type questionSetRepository struct {
@@ -64,28 +57,9 @@ func (q *questionSetRepository) Create(ctx context.Context, set domain.QuestionS
 }
 
 func (q *questionSetRepository) UpdateQuestions(ctx context.Context, set domain.QuestionSet) error {
-	questions := make([]dao.Question, len(set.Questions))
+	qids := make([]int64, len(set.Questions))
 	for i := range set.Questions {
-		d, _ := q.questionD2E.Copy(&set.Questions[i])
-		questions[i] = *d
+		qids[i] = set.Questions[i].Id
 	}
-	return q.dao.UpdateQuestionsByID(ctx, set.Id, questions)
-}
-
-func (q *questionSetRepository) AddQuestions(ctx context.Context, set domain.QuestionSet) error {
-	questions := make([]dao.Question, len(set.Questions))
-	for i := range set.Questions {
-		d, _ := q.questionD2E.Copy(&set.Questions[i])
-		questions[i] = *d
-	}
-	return q.dao.AddQuestionsByID(ctx, set.Id, questions)
-}
-
-func (q *questionSetRepository) DeleteQuestions(ctx context.Context, set domain.QuestionSet) error {
-	questions := make([]dao.Question, len(set.Questions))
-	for i := range set.Questions {
-		d, _ := q.questionD2E.Copy(&set.Questions[i])
-		questions[i] = *d
-	}
-	return q.dao.DeleteQuestionsByID(ctx, set.Id, questions)
+	return q.dao.UpdateQuestionsByID(ctx, set.Id, qids)
 }

--- a/internal/question/internal/repository/question_set.go
+++ b/internal/question/internal/repository/question_set.go
@@ -14,6 +14,8 @@ import (
 type QuestionSetRepository interface {
 	Create(ctx context.Context, set domain.QuestionSet) (int64, error)
 	UpdateQuestions(ctx context.Context, set domain.QuestionSet) error
+	GetByID(ctx context.Context, id int64) (domain.QuestionSet, error)
+	GetByIDAndUID(ctx context.Context, id, uid int64) (domain.QuestionSet, error)
 }
 
 type questionSetRepository struct {
@@ -34,10 +36,10 @@ func NewQuestionSetRepository(d dao.QuestionSetDAO) QuestionSetRepository {
 	if err != nil {
 		panic(err)
 	}
+
 	questionD2E, err := copier.NewReflectCopier[domain.Question, dao.Question](
 		copier.ConvertField[time.Time, int64]("Utime", fieldConverter),
 	)
-
 	if err != nil {
 		panic(err)
 	}
@@ -61,5 +63,64 @@ func (q *questionSetRepository) UpdateQuestions(ctx context.Context, set domain.
 	for i := range set.Questions {
 		qids[i] = set.Questions[i].Id
 	}
-	return q.dao.UpdateQuestionsByID(ctx, set.Id, qids)
+	return q.dao.UpdateQuestionsByIDAndUID(ctx, set.Id, set.Uid, qids)
+}
+
+func (q *questionSetRepository) GetByID(ctx context.Context, id int64) (domain.QuestionSet, error) {
+	set, err := q.dao.GetByID(ctx, id)
+	if err != nil {
+		return domain.QuestionSet{}, err
+	}
+	questions, err := q.getDomainQuestions(ctx, id)
+	if err != nil {
+		return domain.QuestionSet{}, err
+	}
+
+	return domain.QuestionSet{
+		Id:          set.Id,
+		Uid:         set.Uid,
+		Title:       set.Title,
+		Description: set.Description,
+		Questions:   questions,
+		Utime:       time.Unix(set.Utime, 0),
+	}, nil
+}
+
+func (q *questionSetRepository) getDomainQuestions(ctx context.Context, id int64) ([]domain.Question, error) {
+	questionDAOs, err := q.dao.GetQuestionsByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	questionE2D, _ := copier.NewReflectCopier[dao.Question, domain.Question](
+		copier.IgnoreFields("Ctime"),
+		copier.ConvertField[int64, time.Time]("Utime", converter.ConverterFunc[int64, time.Time](func(src int64) (time.Time, error) {
+			return time.Unix(0, src*int64(time.Millisecond)), nil
+		})),
+	)
+	questions := make([]domain.Question, len(questionDAOs))
+	for i, question := range questionDAOs {
+		d, _ := questionE2D.Copy(&question)
+		questions[i] = *d
+	}
+	return questions, nil
+}
+
+func (q *questionSetRepository) GetByIDAndUID(ctx context.Context, id, uid int64) (domain.QuestionSet, error) {
+	set, err := q.dao.GetByIDAndUID(ctx, id, uid)
+	if err != nil {
+		return domain.QuestionSet{}, err
+	}
+	questions, err := q.getDomainQuestions(ctx, id)
+	if err != nil {
+		return domain.QuestionSet{}, err
+	}
+
+	return domain.QuestionSet{
+		Id:          set.Id,
+		Uid:         set.Uid,
+		Title:       set.Title,
+		Description: set.Description,
+		Questions:   questions,
+		Utime:       time.Unix(0, set.Utime*int64(time.Millisecond)),
+	}, nil
 }

--- a/internal/question/internal/service/question_set.go
+++ b/internal/question/internal/service/question_set.go
@@ -10,6 +10,7 @@ import (
 type QuestionSetService interface {
 	Create(ctx context.Context, set domain.QuestionSet) (int64, error)
 	UpdateQuestions(ctx context.Context, set domain.QuestionSet) error
+	Detail(ctx context.Context, id, uid int64) (domain.QuestionSet, error)
 }
 
 type questionSetService struct {
@@ -26,4 +27,8 @@ func (q *questionSetService) Create(ctx context.Context, set domain.QuestionSet)
 
 func (q *questionSetService) UpdateQuestions(ctx context.Context, set domain.QuestionSet) error {
 	return q.repo.UpdateQuestions(ctx, set)
+}
+
+func (q *questionSetService) Detail(ctx context.Context, id, uid int64) (domain.QuestionSet, error) {
+	return q.repo.GetByIDAndUID(ctx, id, uid)
 }

--- a/internal/question/internal/service/question_set.go
+++ b/internal/question/internal/service/question_set.go
@@ -7,16 +7,9 @@ import (
 	"github.com/ecodeclub/webook/internal/question/internal/repository"
 )
 
-var (
-	ErrDuplicatedQuestionID = repository.ErrDuplicatedQuestionID
-)
-
 type QuestionSetService interface {
 	Create(ctx context.Context, set domain.QuestionSet) (int64, error)
-
 	UpdateQuestions(ctx context.Context, set domain.QuestionSet) error
-	AddQuestions(ctx context.Context, set domain.QuestionSet) error
-	DeleteQuestions(ctx context.Context, set domain.QuestionSet) error
 }
 
 type questionSetService struct {
@@ -33,12 +26,4 @@ func (q *questionSetService) Create(ctx context.Context, set domain.QuestionSet)
 
 func (q *questionSetService) UpdateQuestions(ctx context.Context, set domain.QuestionSet) error {
 	return q.repo.UpdateQuestions(ctx, set)
-}
-
-func (q *questionSetService) AddQuestions(ctx context.Context, set domain.QuestionSet) error {
-	return q.repo.AddQuestions(ctx, set)
-}
-
-func (q *questionSetService) DeleteQuestions(ctx context.Context, set domain.QuestionSet) error {
-	return q.repo.DeleteQuestions(ctx, set)
 }

--- a/internal/question/internal/service/question_set.go
+++ b/internal/question/internal/service/question_set.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"context"
+
+	"github.com/ecodeclub/webook/internal/question/internal/domain"
+	"github.com/ecodeclub/webook/internal/question/internal/repository"
+)
+
+var (
+	ErrDuplicatedQuestionID = repository.ErrDuplicatedQuestionID
+)
+
+type QuestionSetService interface {
+	Create(ctx context.Context, set domain.QuestionSet) (int64, error)
+
+	UpdateQuestions(ctx context.Context, set domain.QuestionSet) error
+	AddQuestions(ctx context.Context, set domain.QuestionSet) error
+	DeleteQuestions(ctx context.Context, set domain.QuestionSet) error
+}
+
+type questionSetService struct {
+	repo repository.QuestionSetRepository
+}
+
+func NewQuestionSetService(repo repository.QuestionSetRepository) QuestionSetService {
+	return &questionSetService{repo: repo}
+}
+
+func (q *questionSetService) Create(ctx context.Context, set domain.QuestionSet) (int64, error) {
+	return q.repo.Create(ctx, set)
+}
+
+func (q *questionSetService) UpdateQuestions(ctx context.Context, set domain.QuestionSet) error {
+	return q.repo.UpdateQuestions(ctx, set)
+}
+
+func (q *questionSetService) AddQuestions(ctx context.Context, set domain.QuestionSet) error {
+	return q.repo.AddQuestions(ctx, set)
+}
+
+func (q *questionSetService) DeleteQuestions(ctx context.Context, set domain.QuestionSet) error {
+	return q.repo.DeleteQuestions(ctx, set)
+}

--- a/internal/question/internal/service/question_set.go
+++ b/internal/question/internal/service/question_set.go
@@ -1,3 +1,17 @@
+// Copyright 2023 ecodeclub
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package service
 
 import (
@@ -5,11 +19,13 @@ import (
 
 	"github.com/ecodeclub/webook/internal/question/internal/domain"
 	"github.com/ecodeclub/webook/internal/question/internal/repository"
+	"golang.org/x/sync/errgroup"
 )
 
 type QuestionSetService interface {
 	Create(ctx context.Context, set domain.QuestionSet) (int64, error)
 	UpdateQuestions(ctx context.Context, set domain.QuestionSet) error
+	List(ctx context.Context, offset, limit int, uid int64) ([]domain.QuestionSet, int64, error)
 	Detail(ctx context.Context, id, uid int64) (domain.QuestionSet, error)
 }
 
@@ -31,4 +47,24 @@ func (q *questionSetService) UpdateQuestions(ctx context.Context, set domain.Que
 
 func (q *questionSetService) Detail(ctx context.Context, id, uid int64) (domain.QuestionSet, error) {
 	return q.repo.GetByIDAndUID(ctx, id, uid)
+}
+
+func (q *questionSetService) List(ctx context.Context, offset, limit int, uid int64) ([]domain.QuestionSet, int64, error) {
+	var (
+		eg    errgroup.Group
+		qs    []domain.QuestionSet
+		total int64
+	)
+	eg.Go(func() error {
+		var err error
+		qs, err = q.repo.List(ctx, offset, limit, uid)
+		return err
+	})
+
+	eg.Go(func() error {
+		var err error
+		total, err = q.repo.Total(ctx, uid)
+		return err
+	})
+	return qs, total, eg.Wait()
 }

--- a/internal/question/internal/web/handler.go
+++ b/internal/question/internal/web/handler.go
@@ -15,6 +15,8 @@
 package web
 
 import (
+	"errors"
+	"log"
 	"time"
 
 	"github.com/ecodeclub/ekit/slice"
@@ -30,13 +32,14 @@ import (
 )
 
 type Handler struct {
-	vo2dm  copier.Copier[Question, domain.Question]
-	dm2vo  copier.Copier[domain.Question, Question]
-	svc    service.Service
-	logger *elog.Component
+	vo2dm          copier.Copier[Question, domain.Question]
+	dm2vo          copier.Copier[domain.Question, Question]
+	svc            service.Service
+	questionSetSvc service.QuestionSetService
+	logger         *elog.Component
 }
 
-func NewHandler(svc service.Service) (*Handler, error) {
+func NewHandler(svc service.Service, qss service.QuestionSetService) (*Handler, error) {
 	vo2dm, err := copier.NewReflectCopier[Question, domain.Question](
 		copier.IgnoreFields("Utime"),
 	)
@@ -53,10 +56,11 @@ func NewHandler(svc service.Service) (*Handler, error) {
 		return nil, err
 	}
 	return &Handler{
-		vo2dm:  vo2dm,
-		dm2vo:  dm2vo,
-		svc:    svc,
-		logger: elog.DefaultLogger,
+		vo2dm:          vo2dm,
+		dm2vo:          dm2vo,
+		svc:            svc,
+		questionSetSvc: qss,
+		logger:         elog.DefaultLogger,
 	}, nil
 }
 
@@ -67,6 +71,15 @@ func (h *Handler) PrivateRoutes(server *gin.Engine) {
 	server.POST("/question/publish", ginx.BS[SaveReq](h.Publish))
 	server.POST("/question/pub/list", ginx.B[Page](h.PubList))
 	server.POST("/question/pub/detail", ginx.B[Qid](h.PubDetail))
+
+	server.POST("/question-sets/create", ginx.BS[CreateQuestionSetReq](h.CreateQuestionSet))
+	// 添加/删除题目进去题集 - 批量接口
+	server.POST("/question-sets/add", ginx.BS[AddQuestionsToQuestionSetReq](h.AddQuestionsToQuestionSet))
+	server.POST("/question-sets/delete", ginx.BS[DeleteQuestionsFromQuestionSetReq](h.DeleteQuestionsFromQuestionSet))
+	// 查找题集，分页接口，只有分页参数，不需要传递 UserID
+	server.POST("/question-sets/list", ginx.BS[Page](h.ListQuestionSet))
+	// 题集详情：标题，描述，题目（题目暂时不分页，一个题集不会有很多）。题目包含适合展示在列表上的字段
+	server.POST("/question-sets/detail", ginx.BS[QuestionSetID](h.RetrieveQuestionSetDetail))
 }
 
 func (h *Handler) PublicRoutes(server *gin.Engine) {}
@@ -159,6 +172,93 @@ func (h *Handler) Detail(ctx *ginx.Context, req Qid, sess session.Session) (ginx
 
 func (h *Handler) PubDetail(ctx *ginx.Context, req Qid) (ginx.Result, error) {
 	detail, err := h.svc.PubDetail(ctx, req.Qid)
+	if err != nil {
+		return systemErrorResult, err
+	}
+	vo, err := h.dm2vo.Copy(&detail)
+	return ginx.Result{
+		Data: vo,
+	}, err
+}
+
+// CreateQuestionSet 创建题集
+func (h *Handler) CreateQuestionSet(ctx *ginx.Context, req CreateQuestionSetReq, sess session.Session) (ginx.Result, error) {
+	id, err := h.questionSetSvc.Create(ctx, domain.QuestionSet{Uid: sess.Claims().Uid, Title: req.Title, Description: req.Description})
+	if err != nil {
+		return systemErrorResult, err
+	}
+	return ginx.Result{
+		Data: id,
+	}, nil
+}
+
+// AddQuestionsToQuestionSet 批量更新题集中的问题
+func (h *Handler) AddQuestionsToQuestionSet(ctx *ginx.Context, req AddQuestionsToQuestionSetReq, sess session.Session) (ginx.Result, error) {
+	log.Printf("req = %#v\n", req)
+	questions := make([]domain.Question, len(req.Questions))
+	for i := range req.Questions {
+		d, _ := h.vo2dm.Copy(&req.Questions[i])
+		questions[i] = *d
+	}
+	log.Printf("questions = %#v\n", questions)
+	// todo: 验证题集ID是否属于当前用户
+
+	err := h.questionSetSvc.AddQuestions(ctx.Request.Context(), domain.QuestionSet{
+		Id:        req.QSID,
+		Questions: questions,
+	})
+	if errors.Is(err, service.ErrDuplicatedQuestionID) {
+		return ginx.Result{
+			Code: 402001,
+			Msg:  "部分题目已添加",
+		}, err
+	}
+	if err != nil {
+		log.Printf("err = %#v\n", err)
+		h.logger.Error("AddQuestionsToQuestionSet", elog.FieldErr(err))
+		return systemErrorResult, err
+	}
+	return ginx.Result{}, nil
+}
+
+// DeleteQuestionsFromQuestionSet 批量更新题集中的问题
+func (h *Handler) DeleteQuestionsFromQuestionSet(ctx *ginx.Context, req DeleteQuestionsFromQuestionSetReq, sess session.Session) (ginx.Result, error) {
+	log.Printf("req = %#v\n", req)
+	questions := make([]domain.Question, len(req.Questions))
+	for i := range req.Questions {
+		d, _ := h.vo2dm.Copy(&req.Questions[i])
+		questions[i] = *d
+	}
+	log.Printf("questions = %#v\n", questions)
+	// todo: 验证题集ID是否属于当前用户
+
+	err := h.questionSetSvc.DeleteQuestions(ctx.Request.Context(), domain.QuestionSet{
+		Id:        req.QSID,
+		Questions: questions,
+	})
+	if err != nil {
+		log.Printf("err = %#v\n", err)
+		h.logger.Error("DeleteQuestionsFromQuestionSet", elog.FieldErr(err))
+		return systemErrorResult, err
+	}
+	return ginx.Result{}, nil
+}
+
+func (h *Handler) ListQuestionSet(ctx *ginx.Context, req Page, sess session.Session) (ginx.Result, error) {
+	// todo: 未实现
+	// 制作库不需要统计总数
+	data, cnt, err := h.svc.List(ctx, req.Offset, req.Limit, sess.Claims().Uid)
+	if err != nil {
+		return systemErrorResult, err
+	}
+	return ginx.Result{
+		Data: h.toQuestionList(data, cnt),
+	}, nil
+}
+
+func (h *Handler) RetrieveQuestionSetDetail(ctx *ginx.Context, req QuestionSetID, sess session.Session) (ginx.Result, error) {
+	// todo: 未实现
+	detail, err := h.svc.PubDetail(ctx, req.QuestionSetID)
 	if err != nil {
 		return systemErrorResult, err
 	}

--- a/internal/question/internal/web/question_set_handler.go
+++ b/internal/question/internal/web/question_set_handler.go
@@ -1,0 +1,116 @@
+package web
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/ecodeclub/ekit/bean/copier"
+	"github.com/ecodeclub/ekit/bean/copier/converter"
+	"github.com/ecodeclub/ginx"
+	"github.com/ecodeclub/ginx/session"
+	"github.com/ecodeclub/webook/internal/question/internal/domain"
+	"github.com/ecodeclub/webook/internal/question/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/gotomicro/ego/core/elog"
+)
+
+type QuestionSetHandler struct {
+	vo2dm          copier.Copier[Question, domain.Question]
+	dm2vo          copier.Copier[domain.Question, Question]
+	svc            service.Service
+	questionSetSvc service.QuestionSetService
+	logger         *elog.Component
+}
+
+func NewQuestionSetHandler(qss service.QuestionSetService) (*QuestionSetHandler, error) {
+	vo2dm, err := copier.NewReflectCopier[Question, domain.Question](
+		copier.IgnoreFields("Utime"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	cnvter := converter.ConverterFunc[time.Time, string](func(src time.Time) (string, error) {
+		return src.Format(time.DateTime), nil
+	})
+	dm2vo, err := copier.NewReflectCopier[domain.Question, Question](
+		copier.ConvertField[time.Time, string]("Utime", cnvter),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &QuestionSetHandler{
+		vo2dm:          vo2dm,
+		dm2vo:          dm2vo,
+		questionSetSvc: qss,
+		logger:         elog.DefaultLogger,
+	}, nil
+}
+
+func (h *QuestionSetHandler) PrivateRoutes(server *gin.Engine) {
+
+	server.POST("/question-sets/create", ginx.BS[CreateQuestionSetReq](h.CreateQuestionSet))
+	// 题集更新接口 覆盖式的 前端传递题集中最终的问题集合
+	server.POST("/question-sets/update", ginx.BS[UpdateQuestionsOfQuestionSetReq](h.UpdateQuestionsOfQuestionSet))
+
+	// 查找题集，分页接口，只有分页参数，不需要传递 UserID
+	server.POST("/question-sets/list", ginx.BS[Page](h.ListQuestionSet))
+
+	// 题集详情：标题，描述，题目（题目暂时不分页，一个题集不会有很多）。题目包含适合展示在列表上的字段
+	server.POST("/question-sets/detail", ginx.BS[QuestionSetID](h.RetrieveQuestionSetDetail))
+}
+
+// CreateQuestionSet 创建题集
+func (h *QuestionSetHandler) CreateQuestionSet(ctx *ginx.Context, req CreateQuestionSetReq, sess session.Session) (ginx.Result, error) {
+	id, err := h.questionSetSvc.Create(ctx, domain.QuestionSet{Uid: sess.Claims().Uid, Title: req.Title, Description: req.Description})
+	if err != nil {
+		return systemErrorResult, err
+	}
+	return ginx.Result{
+		Data: id,
+	}, nil
+}
+
+func (h *QuestionSetHandler) UpdateQuestionsOfQuestionSet(ctx *ginx.Context, req UpdateQuestionsOfQuestionSetReq, sess session.Session) (ginx.Result, error) {
+	questions := make([]domain.Question, len(req.QIDs))
+	for i := range req.QIDs {
+		questions[i] = domain.Question{Id: req.QIDs[i]}
+	}
+	log.Printf("questions = %#v\n", questions)
+
+	// todo: 验证题集ID是否属于当前用户
+
+	err := h.questionSetSvc.UpdateQuestions(ctx.Request.Context(), domain.QuestionSet{
+		Id:        req.QSID,
+		Questions: questions,
+	})
+	if err != nil {
+		return systemErrorResult, err
+	}
+	return ginx.Result{}, nil
+}
+
+func (h *QuestionSetHandler) ListQuestionSet(ctx *ginx.Context, req Page, sess session.Session) (ginx.Result, error) {
+	// todo: 未实现
+	// 制作库不需要统计总数
+	data, cnt, err := h.svc.List(ctx, req.Offset, req.Limit, sess.Claims().Uid)
+	if err != nil {
+		return systemErrorResult, err
+	}
+	fmt.Println(cnt)
+	return ginx.Result{
+		Data: data,
+	}, nil
+}
+
+func (h *QuestionSetHandler) RetrieveQuestionSetDetail(ctx *ginx.Context, req QuestionSetID, sess session.Session) (ginx.Result, error) {
+	// todo: 未实现
+	detail, err := h.svc.PubDetail(ctx, req.QuestionSetID)
+	if err != nil {
+		return systemErrorResult, err
+	}
+	vo, err := h.dm2vo.Copy(&detail)
+	return ginx.Result{
+		Data: vo,
+	}, err
+}

--- a/internal/question/internal/web/question_set_handler.go
+++ b/internal/question/internal/web/question_set_handler.go
@@ -59,7 +59,7 @@ func (h *QuestionSetHandler) PrivateRoutes(server *gin.Engine) {
 
 // CreateQuestionSet 创建题集
 func (h *QuestionSetHandler) CreateQuestionSet(ctx *ginx.Context, req CreateQuestionSetReq, sess session.Session) (ginx.Result, error) {
-	id, err := h.svc.Create(ctx, domain.QuestionSet{
+	id, err := h.svc.Create(ctx.Request.Context(), domain.QuestionSet{
 		Uid:         sess.Claims().Uid,
 		Title:       req.Title,
 		Description: req.Description,
@@ -104,7 +104,7 @@ func (h *QuestionSetHandler) ListQuestionSet(ctx *ginx.Context, req Page, sess s
 
 // RetrieveQuestionSetDetail 题集详情
 func (h *QuestionSetHandler) RetrieveQuestionSetDetail(ctx *ginx.Context, req QuestionSetID, sess session.Session) (ginx.Result, error) {
-	data, err := h.svc.Detail(ctx, req.QSID, sess.Claims().Uid)
+	data, err := h.svc.Detail(ctx.Request.Context(), req.QSID, sess.Claims().Uid)
 	if err != nil {
 		return systemErrorResult, err
 	}

--- a/internal/question/internal/web/result.go
+++ b/internal/question/internal/web/result.go
@@ -1,3 +1,17 @@
+// Copyright 2023 ecodeclub
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package web
 
 import (

--- a/internal/question/internal/web/vo.go
+++ b/internal/question/internal/web/vo.go
@@ -81,7 +81,7 @@ type UpdateQuestionsOfQuestionSetReq struct {
 }
 
 type QuestionSetID struct {
-	QuestionSetID int64 `json:"qsid"`
+	QSID int64 `json:"qsid"`
 }
 
 type QuestionSet struct {

--- a/internal/question/internal/web/vo.go
+++ b/internal/question/internal/web/vo.go
@@ -69,3 +69,22 @@ type QuestionList struct {
 	Questions []Question `json:"questions,omitempty"`
 	Total     int64      `json:"total,omitempty"`
 }
+
+type CreateQuestionSetReq struct {
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+type AddQuestionsToQuestionSetReq struct {
+	QSID      int64      `json:"qsid"`
+	Questions []Question `json:"questions,omitempty"`
+}
+
+type DeleteQuestionsFromQuestionSetReq struct {
+	QSID      int64      `json:"qsid"`
+	Questions []Question `json:"questions,omitempty"`
+}
+
+type QuestionSetID struct {
+	QuestionSetID int64 `json:"qsid"`
+}

--- a/internal/question/internal/web/vo.go
+++ b/internal/question/internal/web/vo.go
@@ -75,16 +75,24 @@ type CreateQuestionSetReq struct {
 	Description string `json:"description,omitempty"`
 }
 
-type AddQuestionsToQuestionSetReq struct {
-	QSID      int64      `json:"qsid"`
-	Questions []Question `json:"questions,omitempty"`
-}
-
-type DeleteQuestionsFromQuestionSetReq struct {
-	QSID      int64      `json:"qsid"`
-	Questions []Question `json:"questions,omitempty"`
+type UpdateQuestionsOfQuestionSetReq struct {
+	QSID int64   `json:"qsid"`
+	QIDs []int64 `json:"qids,omitempty"`
 }
 
 type QuestionSetID struct {
 	QuestionSetID int64 `json:"qsid"`
+}
+
+type QuestionSet struct {
+	Id          int64      `json:"id,omitempty"`
+	Title       string     `json:"title,omitempty"`
+	Description string     `json:"description,omitempty"`
+	Questions   []Question `json:"questions,omitempty"`
+	Utime       string     `json:"utime,omitempty"`
+}
+
+type QuestionSetList struct {
+	Total        int64         `json:"total,omitempty"`
+	QuestionSets []QuestionSet `json:"questionSets,omitempty"`
 }

--- a/internal/question/wire.go
+++ b/internal/question/wire.go
@@ -29,13 +29,20 @@ import (
 
 func InitHandler(db *egorm.Component, ec ecache.Cache) (*web.Handler, error) {
 	wire.Build(dao.NewGORMQuestionDAO,
-		dao.NewGORMQuestionSetDAO,
 		cache.NewQuestionECache,
 		repository.NewCacheRepository,
-		repository.NewQuestionSetRepository,
 		service.NewService,
-		service.NewQuestionSetService,
 		web.NewHandler,
 	)
 	return new(web.Handler), nil
+}
+
+func InitQuestionSetHandler(db *egorm.Component, ec ecache.Cache) (*web.QuestionSetHandler, error) {
+	wire.Build(
+		dao.NewGORMQuestionSetDAO,
+		repository.NewQuestionSetRepository,
+		service.NewQuestionSetService,
+		web.NewQuestionSetHandler,
+	)
+	return new(web.QuestionSetHandler), nil
 }

--- a/internal/question/wire.go
+++ b/internal/question/wire.go
@@ -29,9 +29,12 @@ import (
 
 func InitHandler(db *egorm.Component, ec ecache.Cache) (*web.Handler, error) {
 	wire.Build(dao.NewGORMQuestionDAO,
+		dao.NewGORMQuestionSetDAO,
 		cache.NewQuestionECache,
 		repository.NewCacheRepository,
+		repository.NewQuestionSetRepository,
 		service.NewService,
+		service.NewQuestionSetService,
 		web.NewHandler,
 	)
 	return new(web.Handler), nil

--- a/internal/question/wire_gen.go
+++ b/internal/question/wire_gen.go
@@ -23,12 +23,20 @@ func InitHandler(db *gorm.DB, ec ecache.Cache) (*web.Handler, error) {
 	questionCache := cache.NewQuestionECache(ec)
 	repositoryRepository := repository.NewCacheRepository(questionDAO, questionCache)
 	serviceService := service.NewService(repositoryRepository)
-	questionSetDAO := dao.NewGORMQuestionSetDAO(db)
-	questionSetRepository := repository.NewQuestionSetRepository(questionSetDAO)
-	questionSetService := service.NewQuestionSetService(questionSetRepository)
-	handler, err := web.NewHandler(serviceService, questionSetService)
+	handler, err := web.NewHandler(serviceService)
 	if err != nil {
 		return nil, err
 	}
 	return handler, nil
+}
+
+func InitQuestionSetHandler(db *gorm.DB, ec ecache.Cache) (*web.QuestionSetHandler, error) {
+	questionSetDAO := dao.NewGORMQuestionSetDAO(db)
+	questionSetRepository := repository.NewQuestionSetRepository(questionSetDAO)
+	questionSetService := service.NewQuestionSetService(questionSetRepository)
+	questionSetHandler, err := web.NewQuestionSetHandler(questionSetService)
+	if err != nil {
+		return nil, err
+	}
+	return questionSetHandler, nil
 }

--- a/internal/question/wire_gen.go
+++ b/internal/question/wire_gen.go
@@ -23,7 +23,10 @@ func InitHandler(db *gorm.DB, ec ecache.Cache) (*web.Handler, error) {
 	questionCache := cache.NewQuestionECache(ec)
 	repositoryRepository := repository.NewCacheRepository(questionDAO, questionCache)
 	serviceService := service.NewService(repositoryRepository)
-	handler, err := web.NewHandler(serviceService)
+	questionSetDAO := dao.NewGORMQuestionSetDAO(db)
+	questionSetRepository := repository.NewQuestionSetRepository(questionSetDAO)
+	questionSetService := service.NewQuestionSetService(questionSetRepository)
+	handler, err := web.NewHandler(serviceService, questionSetService)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/test/ioc/db.go
+++ b/internal/test/ioc/db.go
@@ -1,6 +1,11 @@
 package testioc
 
 import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/ecodeclub/ekit/retry"
 	"github.com/ego-component/egorm"
 	"github.com/gotomicro/ego/core/econf"
 )
@@ -12,6 +17,35 @@ func InitDB() *egorm.Component {
 		return db
 	}
 	econf.Set("mysql.user", map[string]string{"dsn": "root:root@tcp(localhost:13316)/webook"})
+	WaitForDBSetup()
 	db = egorm.Load("mysql.user").Build()
 	return db
+}
+
+func WaitForDBSetup() {
+	sqlDB, err := sql.Open("mysql", econf.GetStringMapString("mysql.user")["dsn"])
+	if err != nil {
+		panic(err)
+	}
+	const maxInterval = 10 * time.Second
+	const maxRetries = 10
+	strategy, err := retry.NewExponentialBackoffRetryStrategy(time.Second, maxInterval, maxRetries)
+	if err != nil {
+		panic(err)
+	}
+
+	const timeout = 5 * time.Second
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		err = sqlDB.PingContext(ctx)
+		cancel()
+		if err == nil {
+			break
+		}
+		next, ok := strategy.Next()
+		if !ok {
+			panic("WaitForDBSetup 重试失败......")
+		}
+		time.Sleep(next)
+	}
 }


### PR DESCRIPTION
### 题集API设计

1. 创建题集 POST /question-sets/create
- 请求参数: 
```go
type CreateQuestionSetReq struct {
	Title       string `json:"title,omitempty"`
	Description string `json:"description,omitempty"`
}
```
- 相应参数: 题集ID
2. 添加题目到题集 POST /question-sets/add
- 请求参数
```go
type AddQuestionsToQuestionSetReq struct {
	QSID      int64      `json:"qsid"`
	Questions []Question `json:"questions,omitempty"`
}
```
- 响应参数, 200, OK
3. 从题集中删除题目 POST /question-sets/delete
- 请求参数
```go
type DeleteQuestionsFromQuestionSetReq struct {
	QSID      int64      `json:"qsid"`
	Questions []Question `json:"questions,omitempty"`
}
```
- 响应参数, 200, OK
4. 查找题集(查看当前用户的所有题集) POST /question-sets/list
- 请求参数
```go
type Page struct {
	Offset int `json:"offset,omitempty"`
	Limit  int `json:"limit,omitempty"`
}
```
uid从session中获取
- 响应参数
```go
type QuestionSet struct {
	Id          int64      `json:"id,omitempty"`
	Title       string     `json:"title,omitempty"`
	Description string     `json:"description,omitempty"`
	Questions   []Question `json:"questions,omitempty"` // 不知道前端是要题集中所有题集信息还是数字
	Utime       string     `json:"utime,omitempty"`
}

type QuestionSetList struct {
	Total        int64         `json:"total,omitempty"`
	QuestionSets []QuestionSet `json:"questionSets,omitempty"`
}
```
5. 题集详情 POST /question-sets/detail
- 请求参数
```go
type QuestionSetID struct {
	QuestionSetID int64 `json:"qsid"`
}
```
- 响应参数
```go
type QuestionSet struct {
	Id          int64      `json:"id,omitempty"`
	Title       string     `json:"title,omitempty"`
	Description string     `json:"description,omitempty"`
	Questions   []Question `json:"questions,omitempty"`
	Utime       string     `json:"utime,omitempty"`
}
```

### 问题
1. 如何定义错误, 比如用户将一个/多个已经在题集中的题目添加到题集,或者删除一个/多个不再题集中的题目.本想借鉴已有代码,但发现好像都返回systemErrorResult, 500错误
2. API4 原始需求描述为“查找题集，分页接口，只有分页参数，不需要传递 UserID”, 我理解为“使用分页的方式,查看当前用户所创建的所有题集,uid从session中取”是否准确.
