### PR TITLE
fix: 修复member集成测试

### DIFF
--- a/internal/member/internal/integration/integration_test.go
+++ b/internal/member/internal/integration/integration_test.go
@@ -79,14 +79,10 @@ func (s *ModuleTestSuite) TestConsumer_ConsumeRegistrationEvent() {
 	}{
 		"开会员成功_新用户注册": {
 			before: func(t *testing.T, producer mq.Producer, message *mq.Message) {
-				// ctx, cancel := context.WithTimeout(context.Background(), time.Second * 3)
-				// defer cancel()
 				_, err := producer.Produce(context.Background(), message)
 				require.NoError(t, err)
 			},
 			after: func(t *testing.T, uid int64) {
-				// ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
-				// defer cancel()
 				info, err := s.svc.GetMembershipInfo(context.Background(), uid)
 				require.NoError(t, err)
 				require.NotZero(t, info.ID)
@@ -94,7 +90,9 @@ func (s *ModuleTestSuite) TestConsumer_ConsumeRegistrationEvent() {
 			Uid:           1991,
 			errAssertFunc: assert.NoError,
 		},
-		// 开会员失败_新用户注册_优惠已到期
+
+		// 开会员失败_新用户注册_优惠已到期, 无法测到,通过代码审查来补充
+
 		"开会员失败_用户已注册_会员生效中": {
 			before: func(t *testing.T, producer mq.Producer, message *mq.Message) {
 				t.Helper()
@@ -129,7 +127,7 @@ func (s *ModuleTestSuite) TestConsumer_ConsumeRegistrationEvent() {
 		},
 	}
 
-	c, err := event.NewRegistrationEventConsumer(s.svc, s.mq)
+	consumer, err := event.NewRegistrationEventConsumer(s.svc, s.mq)
 	require.NoError(t, err)
 
 	for i := range testCases {
@@ -138,7 +136,7 @@ func (s *ModuleTestSuite) TestConsumer_ConsumeRegistrationEvent() {
 			message := s.newRegistrationEventMessage(t, tc.Uid)
 			tc.before(t, producer, message)
 
-			err = c.Consume(context.Background())
+			err = consumer.Consume(context.Background())
 
 			tc.errAssertFunc(t, err)
 			tc.after(t, tc.Uid)

--- a/internal/member/internal/integration/integration_test.go
+++ b/internal/member/internal/integration/integration_test.go
@@ -17,16 +17,20 @@
 package integration
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/ecodeclub/mq-api"
+	"github.com/ecodeclub/webook/internal/member/internal/domain"
 	"github.com/ecodeclub/webook/internal/member/internal/event"
 	"github.com/ecodeclub/webook/internal/member/internal/integration/startup"
 	"github.com/ecodeclub/webook/internal/member/internal/repository/dao"
 	"github.com/ecodeclub/webook/internal/member/internal/service"
 	testioc "github.com/ecodeclub/webook/internal/test/ioc"
 	"github.com/ego-component/egorm"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -61,99 +65,89 @@ func (s *ModuleTestSuite) TearDownTest() {
 	err := s.db.Exec("TRUNCATE TABLE `members`").Error
 	require.NoError(s.T(), err)
 }
+func (s *ModuleTestSuite) TestConsumer_ConsumeRegistrationEvent() {
+	t := s.T()
+	producer, err := s.mq.Producer("user_registration_events")
+	require.NoError(t, err)
 
-//func (s *ModuleTestSuite) TestConsumer_ConsumeRegistrationEvent() {
-//	t := s.T()
-//	producer, err := s.mq.Producer("user_registration_events")
-//	require.NoError(t, err)
-//
-//	testCases := map[string]struct {
-//		before func(t *testing.T, producer mq.Producer, message *mq.Message)
-//		after  func(t *testing.T, uid int64)
-//
-//		UserID        int64
-//		errAssertFunc assert.ErrorAssertionFunc
-//	}{
-//		"开会员成功_新用户注册": {
-//			before: func(t *testing.T, producer mq.Producer, message *mq.Message) {
-//				//ctx, cancel := context.WithTimeout(context.Background(), time.Second * 3)
-//				//defer cancel()
-//				_, err := producer.Produce(context.Background(), message)
-//				require.NoError(t, err)
-//			},
-//			after: func(t *testing.T, uid int64) {
-//				ctx, cancel := context.WithTimeout(context.Background(), time.Second * 3)
-//				defer cancel()
-//				info, err := s.svc.GetMembershipInfo(ctx, uid)
-//				require.NoError(t, err)
-//				require.NotZero(t, info.ID)
-//			},
-//			UserID: 1991,
-//			errAssertFunc: assert.NoError,
-//		},
-//		"开会员成功_新用户注册_优惠已到期": {
-//			before: func(t *testing.T, producer mq.Producer, message *mq.Message) {
-//				t.Helper()
-//				_, err := producer.Produce(context.Background(), message)
-//				require.NoError(t, err)
-//			},
-//			after:  func(t *testing.T, uid int64) {},
-//			UserID: 1992,
-//			errAssertFunc: assert.Error,
-//		},
-//		"开会员失败_用户已注册_会员生效中": {
-//			before: func(t *testing.T, producer mq.Producer, message *mq.Message) {
-//				t.Helper()
-//				_, err := producer.Produce(context.Background(), message)
-//				require.NoError(t, err)
-//				_, err = s.svc.CreateNewMembership(context.Background(), domain.Member{
-//					UID:     1993,
-//					StartAt: time.Now().UTC().UnixMilli(),
-//					EndAt:   time.Now().Add(time.Hour * 24 * 30).UTC().UnixMilli(),
-//				})
-//				require.NoError(t, err)
-//			},
-//			after:         func(t *testing.T, uid int64) {},
-//			UserID:        1993,
-//			errAssertFunc: assert.Error,
-//		},
-//		"开会员失败_用户已注册_会员已失效": {
-//			before: func(t *testing.T, producer mq.Producer, message *mq.Message) {
-//				t.Helper()
-//				_, err := producer.Produce(context.Background(), message)
-//				require.NoError(t, err)
-//				_, err = s.svc.CreateNewMembership(context.Background(), domain.Member{
-//					UID:     1994,
-//					StartAt: time.Date(2023, 4, 11, 18, 24, 33, 0, time.UTC).UnixMilli(),
-//					EndAt:   time.Date(2023, 6, 30, 23, 59, 59, 0, time.UTC).UnixMilli(),
-//				})
-//				require.NoError(t, err)
-//			},
-//			after:         func(t *testing.T, uid int64) {},
-//			UserID:        1994,
-//			errAssertFunc: assert.Error,
-//		},
-//	}
-//
-//	for i := range testCases {
-//		name, tc := i, testCases[i]
-//		t.Run(name, func(t *testing.T) {
-//			message := s.newRegistrationEventMessage(t, tc.UserID)
-//			tc.before(t, producer, message)
-//			evtConsumer, err := event.NewRegistrationEventConsumer(s.svc, s.mq)
-//			require.NoError(t, err)
-//			ctx, cancel := context.WithTimeout(context.Background(), time.Second * 3)
-//			defer cancel()
-//			err = evtConsumer.Consume(ctx)
-//			tc.errAssertFunc(t, err)
-//
-//			tc.after(t, tc.UserID)
-//		})
-//	}
-//}
+	testCases := map[string]struct {
+		before func(t *testing.T, producer mq.Producer, message *mq.Message)
+		after  func(t *testing.T, uid int64)
 
-func (s *ModuleTestSuite) newRegistrationEventMessage(t *testing.T, userID int64) *mq.Message {
-	marshal, err := json.Marshal(event.RegistrationEvent{Uid: userID})
+		Uid           int64
+		errAssertFunc assert.ErrorAssertionFunc
+	}{
+		"开会员成功_新用户注册": {
+			before: func(t *testing.T, producer mq.Producer, message *mq.Message) {
+				// ctx, cancel := context.WithTimeout(context.Background(), time.Second * 3)
+				// defer cancel()
+				_, err := producer.Produce(context.Background(), message)
+				require.NoError(t, err)
+			},
+			after: func(t *testing.T, uid int64) {
+				// ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+				// defer cancel()
+				info, err := s.svc.GetMembershipInfo(context.Background(), uid)
+				require.NoError(t, err)
+				require.NotZero(t, info.ID)
+			},
+			Uid:           1991,
+			errAssertFunc: assert.NoError,
+		},
+		// 开会员失败_新用户注册_优惠已到期
+		"开会员失败_用户已注册_会员生效中": {
+			before: func(t *testing.T, producer mq.Producer, message *mq.Message) {
+				t.Helper()
+				_, err := producer.Produce(context.Background(), message)
+				require.NoError(t, err)
+				_, err = s.svc.CreateNewMembership(context.Background(), domain.Member{
+					UID:     1993,
+					StartAt: time.Now().UnixMilli(),
+					EndAt:   time.Now().Add(time.Hour).UnixMilli(),
+				})
+				require.NoError(t, err)
+			},
+			after:         func(t *testing.T, uid int64) {},
+			Uid:           1993,
+			errAssertFunc: assert.Error,
+		},
+		"开会员失败_用户已注册_会员已失效": {
+			before: func(t *testing.T, producer mq.Producer, message *mq.Message) {
+				t.Helper()
+				_, err := producer.Produce(context.Background(), message)
+				require.NoError(t, err)
+				_, err = s.svc.CreateNewMembership(context.Background(), domain.Member{
+					UID:     1994,
+					StartAt: time.Date(2023, 4, 11, 18, 24, 33, 0, time.UTC).UnixMilli(),
+					EndAt:   time.Date(2023, 6, 30, 23, 59, 59, 0, time.UTC).UnixMilli(),
+				})
+				require.NoError(t, err)
+			},
+			after:         func(t *testing.T, uid int64) {},
+			Uid:           1994,
+			errAssertFunc: assert.Error,
+		},
+	}
+
+	c, err := event.NewRegistrationEventConsumer(s.svc, s.mq)
+	require.NoError(t, err)
+
+	for i := range testCases {
+		name, tc := i, testCases[i]
+		t.Run(name, func(t *testing.T) {
+			message := s.newRegistrationEventMessage(t, tc.Uid)
+			tc.before(t, producer, message)
+
+			err = c.Consume(context.Background())
+
+			tc.errAssertFunc(t, err)
+			tc.after(t, tc.Uid)
+		})
+	}
+}
+
+func (s *ModuleTestSuite) newRegistrationEventMessage(t *testing.T, uid int64) *mq.Message {
+	marshal, err := json.Marshal(event.RegistrationEvent{Uid: uid})
 	require.NoError(t, err)
 	return &mq.Message{Value: marshal}
 }

--- a/internal/member/module.go
+++ b/internal/member/module.go
@@ -14,6 +14,9 @@
 
 package member
 
+import "github.com/ecodeclub/webook/internal/member/internal/event"
+
 type Module struct {
 	Svc Service
+	c   *event.RegistrationEventConsumer
 }

--- a/internal/member/wire.go
+++ b/internal/member/wire.go
@@ -37,6 +37,7 @@ func InitModule(db *egorm.Component, q mq.MQ) (*Module, error) {
 	wire.Build(wire.Struct(
 		new(Module), "*"),
 		InitService,
+		initRegistrationConsumer,
 	)
 	return new(Module), nil
 }
@@ -52,15 +53,15 @@ func InitService(db *egorm.Component, q mq.MQ) Service {
 		d := dao.NewMemberGORMDAO(db)
 		r := repository.NewMemberRepository(d)
 		svc = service.NewMemberService(r)
-		initRegistrationConsumer(svc, q)
 	})
 	return svc
 }
 
-func initRegistrationConsumer(svc service.Service, q mq.MQ) {
+func initRegistrationConsumer(svc service.Service, q mq.MQ) *event.RegistrationEventConsumer {
 	c, err := event.NewRegistrationEventConsumer(svc, q)
 	if err != nil {
 		panic(err)
 	}
 	c.Start(context.Background())
+	return c
 }

--- a/internal/member/wire_gen.go
+++ b/internal/member/wire_gen.go
@@ -24,8 +24,10 @@ import (
 
 func InitModule(db *gorm.DB, q mq.MQ) (*Module, error) {
 	service := InitService(db, q)
+	registrationEventConsumer := initRegistrationConsumer(service, q)
 	module := &Module{
 		Svc: service,
+		c:   registrationEventConsumer,
 	}
 	return module, nil
 }
@@ -47,15 +49,15 @@ func InitService(db *egorm.Component, q mq.MQ) Service {
 		d := dao.NewMemberGORMDAO(db)
 		r := repository.NewMemberRepository(d)
 		svc = service.NewMemberService(r)
-		initRegistrationConsumer(svc, q)
 	})
 	return svc
 }
 
-func initRegistrationConsumer(svc2 service.Service, q mq.MQ) {
+func initRegistrationConsumer(svc2 service.Service, q mq.MQ) *event.RegistrationEventConsumer {
 	c, err := event.NewRegistrationEventConsumer(svc2, q)
 	if err != nil {
 		panic(err)
 	}
 	c.Start(context.Background())
+	return c
 }


### PR DESCRIPTION
1. test/ioc中添加topic初始化信息, 不添加kafka并不会自动创建, 会导致测试卡住
2. 消费者初始化时机改为InitModule中