### PR TITLE
refactor: 重构订单模块

### DIFF
--- a/internal/order/internal/repository/repository.go
+++ b/internal/order/internal/repository/repository.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/ecodeclub/ekit/slice"
+	"github.com/ecodeclub/ekit/sqlx"
 	"github.com/ecodeclub/webook/internal/order/internal/domain"
 	"github.com/ecodeclub/webook/internal/order/internal/repository/dao"
 )
@@ -61,8 +62,8 @@ func (o *orderRepository) toOrderEntity(order domain.Order) dao.Order {
 		Id:                 order.ID,
 		SN:                 order.SN,
 		BuyerId:            order.BuyerID,
-		PaymentId:          order.Payment.ID,
-		PaymentSn:          order.Payment.SN,
+		PaymentId:          sqlx.NewNullInt64(order.Payment.ID),
+		PaymentSn:          sqlx.NewNullString(order.Payment.SN),
 		OriginalTotalPrice: order.OriginalTotalPrice,
 		RealTotalPrice:     order.RealTotalPrice,
 		Status:             order.Status.ToUint8(),
@@ -108,8 +109,8 @@ func (o *orderRepository) toOrderDomain(order dao.Order, orderItems []dao.OrderI
 		SN:      order.SN,
 		BuyerID: order.BuyerId,
 		Payment: domain.Payment{
-			ID: order.PaymentId,
-			SN: order.PaymentSn,
+			ID: order.PaymentId.Int64,
+			SN: order.PaymentSn.String,
 		},
 		OriginalTotalPrice: order.OriginalTotalPrice,
 		RealTotalPrice:     order.RealTotalPrice,

--- a/internal/order/internal/web/handler.go
+++ b/internal/order/internal/web/handler.go
@@ -48,7 +48,7 @@ func NewHandler(svc service.Service, paymentSvc payment.Service, productSvc prod
 
 func (h *Handler) PrivateRoutes(server *gin.Engine) {
 	g := server.Group("/order")
-	g.POST("/preview", ginx.BS[PreviewOrderReq](h.RetrievePreviewOrder))
+	g.POST("/preview", ginx.BS[PreviewOrderReq](h.PreviewOrder))
 	g.POST("/create", ginx.BS[CreateOrderReq](h.CreateOrderAndPayment))
 	g.POST("", ginx.BS[RetrieveOrderStatusReq](h.RetrieveOrderStatus))
 	g.POST("/list", ginx.BS[ListOrdersReq](h.ListOrders))
@@ -58,8 +58,8 @@ func (h *Handler) PrivateRoutes(server *gin.Engine) {
 
 func (h *Handler) PublicRoutes(_ *gin.Engine) {}
 
-// RetrievePreviewOrder 获取订单预览信息, 此时订单尚未创建
-func (h *Handler) RetrievePreviewOrder(ctx *ginx.Context, req PreviewOrderReq, sess session.Session) (ginx.Result, error) {
+// PreviewOrder 获取订单预览信息, 此时订单尚未创建
+func (h *Handler) PreviewOrder(ctx *ginx.Context, req PreviewOrderReq, sess session.Session) (ginx.Result, error) {
 	p, err := h.productSvc.FindSKUBySN(ctx.Request.Context(), req.SKUSN)
 	if err != nil {
 		return systemErrorResult, fmt.Errorf("商品SKU序列号非法: %w", err)
@@ -116,7 +116,7 @@ func (h *Handler) CreateOrderAndPayment(ctx *ginx.Context, req CreateOrderReq, s
 		return systemErrorResult, fmt.Errorf("创建订单失败: %w", err)
 	}
 
-	p, err := h.createPayment(ctx, order, req.Payments)
+	p, err := h.createPayment(ctx, order, req.PaymentItems)
 	if err != nil {
 		// 创建支付失败
 		return systemErrorResult, fmt.Errorf("创建支付失败: %w", err)
@@ -153,6 +153,8 @@ func (h *Handler) checkRequestID(ctx context.Context, requestID string) error {
 	if !val.KeyNotFound() {
 		return fmt.Errorf("重复请求")
 	}
+	// TODO: 这里有一个隐患，就是如果要是最终并没有创建 ORDER 成功，
+	//       这会要求用户必须重新创建一个订单
 	if err := h.cache.Set(ctx, key, requestID, 0); err != nil {
 		return fmt.Errorf("缓存请求ID失败: %w", err)
 	}
@@ -167,12 +169,6 @@ func (h *Handler) createOrder(ctx context.Context, req CreateOrderReq, buyerID i
 	orderItems, originalTotalPrice, realTotalPrice, err := h.getOrderItems(ctx, req)
 	if err != nil {
 		return domain.Order{}, err
-	}
-	if originalTotalPrice != req.OriginalTotalPrice {
-		return domain.Order{}, fmt.Errorf("商品总原价非法")
-	}
-	if realTotalPrice != req.RealTotalPrice {
-		return domain.Order{}, fmt.Errorf("商品总实价非法")
 	}
 
 	orderSN, err := h.snGenerator.Generate(buyerID)
@@ -203,17 +199,13 @@ func (h *Handler) getOrderItems(ctx context.Context, req CreateOrderReq) ([]doma
 		}
 		if skuReq.Quantity < 1 || skuReq.Quantity > sku.Stock {
 			// todo: 重新审视stockLimit的意义及用法
+			// 暂时不需要修改
 			return nil, 0, 0, fmt.Errorf("商品数量非法")
-		}
-		spu, err := h.productSvc.FindSPUByID(ctx, sku.SPUID)
-		if err != nil {
-			// SN非法
-			return nil, 0, 0, fmt.Errorf("商品SPUSN非法: %w", err)
 		}
 
 		item := domain.OrderItem{
 			SKU: domain.SKU{
-				SPUID:         spu.ID,
+				SPUID:         sku.SPUID,
 				ID:            sku.ID,
 				SN:            sku.SN,
 				Image:         sku.Image,
@@ -233,6 +225,7 @@ func (h *Handler) getOrderItems(ctx context.Context, req CreateOrderReq) ([]doma
 
 func (h *Handler) createPayment(ctx context.Context, order domain.Order, paymentChannels []PaymentItem) (payment.Payment, error) {
 	records := make([]payment.Record, 0, len(paymentChannels))
+	realTotalPrice := int64(0)
 	for _, pc := range paymentChannels {
 		if pc.Type != payment.ChannelTypeCredit && pc.Type != payment.ChannelTypeWechat {
 			return payment.Payment{}, fmt.Errorf("支付渠道非法")
@@ -241,6 +234,10 @@ func (h *Handler) createPayment(ctx context.Context, order domain.Order, payment
 			Amount:  pc.Amount,
 			Channel: pc.Type,
 		})
+		realTotalPrice += pc.Amount
+	}
+	if realTotalPrice != order.RealTotalPrice {
+		return payment.Payment{}, fmt.Errorf("支付信息错误：金额不匹配")
 	}
 	return h.paymentSvc.CreatePayment(ctx, payment.Payment{
 		OrderID:     order.ID,

--- a/internal/order/internal/web/vo.go
+++ b/internal/order/internal/web/vo.go
@@ -16,15 +16,13 @@ package web
 
 // PreviewOrderReq 预览订单请求
 type PreviewOrderReq struct {
-	SKUSN    string `json:"sn"`
-	Quantity int64  `json:"quantity"`
+	SKUs []SKU `json:"skus"` // 商品信息
 }
 
 type PreviewOrderResp struct {
-	Credits  uint64        `json:"credits"`  // 积分总数
-	Payments []PaymentItem `json:"payments"` // 支付通道
-	SKUs     []SKU         `json:"skus"`     // 商品信息
-	Policy   string        `json:"policy"`   // 政策信息
+	Order   Order  `json:"order"`   // 预览oder, 包含支持的渠道, 和要购买的SKU
+	Credits uint64 `json:"credits"` // 积分总数
+	Policy  string `json:"policy"`  // 政策信息
 }
 
 type SKU struct {

--- a/internal/order/internal/web/vo.go
+++ b/internal/order/internal/web/vo.go
@@ -44,11 +44,9 @@ type PaymentItem struct {
 
 // CreateOrderReq 创建订单请求
 type CreateOrderReq struct {
-	RequestID          string        `json:"requestID"`       // 请求去重,防止订单重复提交
-	SKUs               []SKU         `json:"skus"`            // 商品信息
-	Payments           []PaymentItem `json:"paymentChannels"` // 支付通道
-	OriginalTotalPrice int64         `json:"originalTotalPrice"`
-	RealTotalPrice     int64         `json:"realTotalPrice"`
+	RequestID    string        `json:"requestID"`    // 请求去重,防止订单重复提交
+	SKUs         []SKU         `json:"skus"`         // 商品信息
+	PaymentItems []PaymentItem `json:"paymentItems"` // 支付通道
 }
 
 type CreateOrderResp struct {

--- a/internal/pkg/sequencenumber/sequence_number_generator.go
+++ b/internal/pkg/sequencenumber/sequence_number_generator.go
@@ -51,5 +51,6 @@ func (s *Generator) Generate(id int64) (string, error) {
 	timestamp := s.timestampGenFunc(time.Now())
 	lastFour := fmt.Sprintf("%04d", id%10000)
 	uuid := s.shortUUIDGenFunc()
+	// timestamp 的16进制编码 + 用户后四位 + (uuid 凑够位数) == 32 位
 	return fmt.Sprintf("%d%s%s", timestamp, lastFour, uuid), nil
 }


### PR DESCRIPTION
1. 重构PreviewOrder
```go
// PreviewOrderReq 预览订单请求
type PreviewOrderReq struct {
	SKUs []SKU `json:"skus"` // 商品信息
}

type PreviewOrderResp struct {
	Order   Order  `json:"order"`   // 预览oder, 包含支持的渠道, 和要购买的SKU
	Credits uint64 `json:"credits"` // 积分总数
	Policy  string `json:"policy"`  // 政策信息
}
```
2. #101  中与订单相关的内容