### PR TITLE
feat(marketing): 添加管理员生成兑换码API

### DIFF
--- a/internal/marketing/internal/service/admin.go
+++ b/internal/marketing/internal/service/admin.go
@@ -1,0 +1,39 @@
+// Copyright 2023 ecodeclub
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+
+	"github.com/ecodeclub/webook/internal/marketing/internal/domain"
+	"github.com/ecodeclub/webook/internal/marketing/internal/repository"
+)
+
+type RedemptionCodeAdminService interface {
+	GenerateRedemptionCodes(ctx context.Context, codes []domain.RedemptionCode) error
+}
+
+type adminService struct {
+	repo repository.MarketingRepository
+}
+
+func NewAdminService(repo repository.MarketingRepository) RedemptionCodeAdminService {
+	return &adminService{repo: repo}
+}
+
+func (a *adminService) GenerateRedemptionCodes(ctx context.Context, codes []domain.RedemptionCode) error {
+	_, err := a.repo.CreateRedemptionCodes(ctx, codes)
+	return err
+}

--- a/internal/marketing/internal/web/admin.go
+++ b/internal/marketing/internal/web/admin.go
@@ -1,0 +1,89 @@
+// Copyright 2023 ecodeclub
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package web
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ecodeclub/ginx"
+	"github.com/ecodeclub/ginx/session"
+	"github.com/ecodeclub/webook/internal/marketing/internal/domain"
+	"github.com/ecodeclub/webook/internal/marketing/internal/service"
+	"github.com/ecodeclub/webook/internal/product"
+	"github.com/gin-gonic/gin"
+)
+
+type AdminHandler struct {
+	svc                     service.RedemptionCodeAdminService
+	productSvc              product.Service
+	redemptionCodeGenerator func(id int64) string
+}
+
+func NewAdminHandler(svc service.RedemptionCodeAdminService, productSvc product.Service, redemptionCodeGenerator func(id int64) string) *AdminHandler {
+	return &AdminHandler{
+		svc:                     svc,
+		productSvc:              productSvc,
+		redemptionCodeGenerator: redemptionCodeGenerator,
+	}
+}
+
+func (h *AdminHandler) PrivateRoutes(server *gin.Engine) {
+	g := server.Group("/code")
+	g.POST("/gen", ginx.BS[GenerateRedemptionCodeReq](h.GenerateRedemptionCode))
+}
+
+func (h *AdminHandler) GenerateRedemptionCode(ctx *ginx.Context, req GenerateRedemptionCodeReq, sess session.Session) (ginx.Result, error) {
+	codes, err := h.generateCodes(ctx.Request.Context(), req)
+	if err != nil {
+		return systemErrorResult, err
+	}
+	err = h.svc.GenerateRedemptionCodes(ctx.Request.Context(), codes)
+	if err != nil {
+		return systemErrorResult, err
+	}
+	return ginx.Result{Msg: "OK"}, nil
+}
+
+func (h *AdminHandler) generateCodes(ctx context.Context, req GenerateRedemptionCodeReq) ([]domain.RedemptionCode, error) {
+	sku, err := h.productSvc.FindSKUBySN(ctx, req.SKUSN)
+	if err != nil {
+		return nil, fmt.Errorf("获取SKU信息失败: %w", err)
+	}
+	spu, err := h.productSvc.FindSPUByID(ctx, sku.SPUID)
+	if err != nil {
+		return nil, fmt.Errorf("获取SPU信息失败: %w", err)
+	}
+	codes := make([]domain.RedemptionCode, 0, req.Count)
+	for i := 0; i < req.Count; i++ {
+		codes = append(codes, h.generateCode(req, spu, sku))
+	}
+	return codes, nil
+}
+
+func (h *AdminHandler) generateCode(req GenerateRedemptionCodeReq, spu product.SPU, sku product.SKU) domain.RedemptionCode {
+	return domain.RedemptionCode{
+		OwnerID: 0, // ownerID为0表示admin
+		Biz:     req.Biz,
+		BizId:   req.BizId,
+		Type:    spu.Category1,
+		Attrs: domain.CodeAttrs{SKU: domain.SKU{
+			ID:    sku.ID,
+			Attrs: sku.Attrs,
+		}},
+		Code:   h.redemptionCodeGenerator(req.BizId),
+		Status: domain.RedemptionCodeStatusUnused,
+	}
+}

--- a/internal/marketing/internal/web/vo.go
+++ b/internal/marketing/internal/web/vo.go
@@ -35,3 +35,10 @@ type RedemptionCode struct {
 	Status uint8  `json:"status"`
 	Utime  int64  `json:"utime"`
 }
+
+type GenerateRedemptionCodeReq struct {
+	Biz   string `json:"biz"`    // admin
+	BizId int64  `json:"biz_id"` // 时间戳
+	SKUSN string `json:"sku_sn"` // 某个商品 —— 7天会员,面试项目,毕业季大礼包
+	Count int    `json:"count"`  // 生成的个数
+}

--- a/internal/marketing/module.go
+++ b/internal/marketing/module.go
@@ -17,7 +17,7 @@ package marketing
 import "github.com/ecodeclub/webook/internal/marketing/internal/event/consumer"
 
 type Module struct {
-	Svc           Service
+	AdminHdl      *AdminHandler
 	Hdl           *Handler
 	orderConsumer *consumer.OrderEventConsumer
 }

--- a/internal/marketing/wire.go
+++ b/internal/marketing/wire.go
@@ -36,8 +36,9 @@ import (
 )
 
 type (
-	Service = service.Service
-	Handler = web.Handler
+	Service      = service.Service
+	Handler      = web.Handler
+	AdminHandler = web.AdminHandler
 )
 
 func InitModule(db *egorm.Component, q mq.MQ, om *order.Module, pm *product.Module) (*Module, error) {
@@ -54,7 +55,8 @@ func InitModule(db *egorm.Component, q mq.MQ, om *order.Module, pm *product.Modu
 		producer.NewPermissionEventProducer,
 		service.NewService,
 		web.NewHandler,
-
+		service.NewAdminService,
+		web.NewAdminHandler,
 		newOrderEventConsumer,
 		wire.Struct(new(Module), "*"),
 	)

--- a/ioc/admin.go
+++ b/ioc/admin.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ecodeclub/ginx"
 	"github.com/ecodeclub/ginx/session"
 	"github.com/ecodeclub/webook-private/nonsense"
+	"github.com/ecodeclub/webook/internal/marketing"
 	"github.com/ecodeclub/webook/internal/project"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -30,7 +31,8 @@ import (
 
 type AdminServer *egin.Component
 
-func InitAdminServer(prj *project.AdminHandler) AdminServer {
+func InitAdminServer(prj *project.AdminHandler,
+	mark *marketing.AdminHandler) AdminServer {
 	res := egin.Load("admin").Build()
 	res.Use(cors.New(cors.Config{
 		ExposeHeaders:    []string{"X-Refresh-Token", "X-Access-Token"},
@@ -54,6 +56,7 @@ func InitAdminServer(prj *project.AdminHandler) AdminServer {
 	res.Use(session.CheckLoginMiddleware())
 	res.Use(AdminPermission())
 	prj.PrivateRoutes(res.Engine)
+	mark.PrivateRoutes(res.Engine)
 	return res
 }
 

--- a/ioc/wire.go
+++ b/ioc/wire.go
@@ -67,7 +67,7 @@ func InitApp() (*App, error) {
 		recon.InitModule,
 		wire.FieldsOf(new(*recon.Module), "SyncPaymentAndOrderJob"),
 		marketing.InitModule,
-		wire.FieldsOf(new(*marketing.Module), "Hdl"),
+		wire.FieldsOf(new(*marketing.Module), "AdminHdl", "Hdl"),
 		interactive.InitModule,
 		wire.FieldsOf(new(*interactive.Module), "Hdl"),
 

--- a/ioc/wire_gen.go
+++ b/ioc/wire_gen.go
@@ -100,7 +100,8 @@ func InitApp() (*App, error) {
 	handler13 := interactiveModule.Hdl
 	component := initGinxServer(provider, checkMembershipMiddlewareBuilder, handler, questionSetHandler, webHandler, handler2, handler3, handler4, handler5, handler6, handler7, handler8, handler9, handler10, handler11, handler12, handler13)
 	adminHandler := projectModule.AdminHdl
-	adminServer := InitAdminServer(adminHandler)
+	webAdminHandler := marketingModule.AdminHdl
+	adminServer := InitAdminServer(adminHandler, webAdminHandler)
 	closeTimeoutOrdersJob := orderModule.CloseTimeoutOrdersJob
 	closeTimeoutLockedCreditsJob := creditModule.CloseTimeoutLockedCreditsJob
 	syncWechatOrderJob := paymentModule.SyncWechatOrderJob


### PR DESCRIPTION
待确认:
1. 管理员生成兑换码API (已在本pr中实现,实现如下:)
```go
// 路径 POST /code/gen 
// 请求参数
type GenerateRedemptionCodeReq struct {
	Biz   string `json:"biz"`    // admin
	BizId int64  `json:"biz_id"` // 时间戳
	SKUSN string `json:"sku_sn"` // 某个商品 —— 7天会员,面试项目,毕业季大礼包, 后端会根据SN事实查询产品模块生成兑换码
	Count int    `json:"count"`  // 生成兑换码的个数
}
// 响应参数
// OK
```
2. 后续是否需要管理员分页查询生成的兑换码?
    - 如果需要, 当前管理员在后端用ownerId=0表示, 因此前端直接传递req{offset, limit}即可,返回的code可以带上type,前端可以通过type过滤查看某一类的兑换码
